### PR TITLE
Fill getHeader() in APIException class

### DIFF
--- a/templates/java/src/main/java/com/facebook/ads/sdk/APIException.java
+++ b/templates/java/src/main/java/com/facebook/ads/sdk/APIException.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.List;
 
 public class APIException extends Exception implements APIResponse {
+  private String header;
 
   public APIException () {
     super();
@@ -43,6 +44,11 @@ public class APIException extends Exception implements APIResponse {
 
   public APIException (String message, Throwable e) {
     super(message, e);
+  }
+
+  public APIException (String header, String message, Throwable e) {
+    super(message, e);
+    this.header = header;
   }
 
   @Override
@@ -68,7 +74,7 @@ public class APIException extends Exception implements APIResponse {
 
   @Override
   public String getHeader() {
-    return null;
+    return this.header;
   }
 
   public static class MalformedResponseException extends APIException {
@@ -104,6 +110,10 @@ public class APIException extends Exception implements APIResponse {
 
     public FailedRequestException (String message, Throwable e) {
       super(message, e);
+    }
+
+    public FailedRequestException (String header, String message, Throwable e) {
+      super(header, message, e);
     }
   }
 }

--- a/templates/java/src/main/java/com/facebook/ads/sdk/APIRequest.java
+++ b/templates/java/src/main/java/com/facebook/ads/sdk/APIRequest.java
@@ -303,7 +303,9 @@ public class APIRequest<T extends APINode> {
         response.append(inputLine);
       }
       in.close();
-      throw new APIException.FailedRequestException(response.toString(), e);
+      throw new APIException.FailedRequestException(
+        convertToString(con.getHeaderFields()), response.toString(), e
+      );
     }
   }
 

--- a/templates/ruby/lib/facebook_ads/api_response.rb
+++ b/templates/ruby/lib/facebook_ads/api_response.rb
@@ -38,6 +38,10 @@ module FacebookAds
       @body
     end
 
+    def headers
+      @headers
+    end
+
     private
     def is_json_response?
       headers[:content_type] =~ /application\/json/ ||

--- a/templates/ruby/lib/facebook_ads/errors.rb
+++ b/templates/ruby/lib/facebook_ads/errors.rb
@@ -24,7 +24,7 @@ module FacebookAds
 
   class APIError < Error
     ERROR_ATTRS = [
-      :fb_message, :type, :code,
+      :headers, :fb_message, :type, :code,
       :error_subcode, :is_transient, :error_user_title,
       :error_user_msg, :fbtrace_id,
     ]
@@ -32,6 +32,7 @@ module FacebookAds
     attr_accessor *ERROR_ATTRS
 
     def initialize(api_response)
+      send("headers=", api_response.headers)
       error_obj = api_response.result
       @api_response = api_response
 
@@ -46,6 +47,10 @@ module FacebookAds
       else
         super(error_obj)
       end
+    end
+
+    def getHeaders
+      self.headers
     end
   end
 


### PR DESCRIPTION
Summary: Filled out function *getHeader()* in APIException class in order to provide header information

Reviewed By: jingping2015

Differential Revision: D18544054

