### PR TITLE
Removing 'node_modules' folder from Ignore list in flowconfig file

### DIFF
--- a/templates/nodejs/.flowconfig
+++ b/templates/nodejs/.flowconfig
@@ -1,5 +1,4 @@
 [ignore]
-.*node_modules.*
 .*dist.*
 .*docs/.*
 .*examples/.*


### PR DESCRIPTION
Summary: Removing 'node_modules' folder from Ignore list in flowconfig file will let it scan under node_modules and not throw flow errors for the require statement.

Reviewed By: jingping2015

Differential Revision: D19145169

