### PR TITLE
Remove types_first from .flowconfig and fix flow errors

### DIFF
--- a/templates/nodejs/src/abstract-object.js
+++ b/templates/nodejs/src/abstract-object.js
@@ -14,9 +14,14 @@
 export default class AbstractObject {
   _data: any;
   _fields: Array<string>;
-  static get Fields() {
+  // This is a Flow workaround for setting `this[field]` in the set() function.
+  $key: string;
+  $value: mixed;
+
+  static get Fields(): {} {
     return Object.freeze({});
   }
+
   constructor() {
     this._data = {};
     if (this.constructor.Fields === undefined) {
@@ -55,8 +60,7 @@ export default class AbstractObject {
     if (this._fields.indexOf(field) < 0) {
       this._defineProperty(field);
     }
-    var that: {[key: string]: any} = this;
-    that[field] = value;
+    this[field] = value;
     return this;
   }
 

--- a/templates/nodejs/src/api-batch.js
+++ b/templates/nodejs/src/api-batch.js
@@ -31,7 +31,7 @@ class FacebookAdsApiBatch {
     api: FacebookAdsApi,
     successCallback?: Function,
     failureCallback?: Function,
-  ) {
+  ): void {
     this._api = api;
     this._files = [];
     this._batch = [];
@@ -75,7 +75,13 @@ class FacebookAdsApiBatch {
     successCallback?: Function,
     failureCallback?: Function,
     request?: APIRequest,
-  ) {
+  ): {|
+    attachedFiles: (void | string),
+    body: (void | string),
+    method: string,
+    name: (void | any),
+    relative_url: string
+  |} {
     // Construct a relaitveUrl from relateivePath by assuming that
     // relativePath can only be a string or an array of strings
     var relativeUrl =
@@ -143,7 +149,13 @@ class FacebookAdsApiBatch {
     request: APIRequest,
     successCallback?: Function,
     failureCallback?: Function,
-  ) {
+  ): {|
+    attachedFiles: (void | string),
+    body: (void | string),
+    method: string,
+    name: (void | any),
+    relative_url: string
+  |} {
     const updatedParams = request.params;
     updatedParams['fields'] = request.fields.join();
 
@@ -169,7 +181,7 @@ class FacebookAdsApiBatch {
    *   returns a new FacebookAdsApiBatch object with those calls.
    *   Otherwise, returns None.
    */
-  execute() {
+  execute(): void | Promise<mixed> {
     if (this._batch.length < 1) {
       return;
     }

--- a/templates/nodejs/src/api-response.js
+++ b/templates/nodejs/src/api-response.js
@@ -20,7 +20,7 @@ class APIResponse {
   _call: Object;
   _response: Object;
 
-  constructor(response: Object, call?: Object) {
+  constructor(response: Object, call?: Object): void {
     response.body = JSON.parse(response.body);
     this._body = response.body;
     this._httpStatus = response.code;
@@ -32,23 +32,23 @@ class APIResponse {
   /**
    * @return {Object} The response body
    */
-  get body() {
+  get body(): any {
     return this._body;
   }
 
-  get headers() {
+  get headers(): any {
     return this._headers;
   }
 
-  get etag() {
+  get etag(): any {
     return this._headers['ETag'];
   }
 
-  get status() {
+  get status(): string {
     return this._httpStatus;
   }
 
-  get isSuccess() {
+  get isSuccess(): boolean {
     const body = this._body;
 
     if ('error' in body) {
@@ -70,7 +70,7 @@ class APIResponse {
     }
   }
 
-  get error() {
+  get error(): any {
     if (this.isSuccess) {
       return null;
     }

--- a/templates/nodejs/src/api.js.versioned.mustache
+++ b/templates/nodejs/src/api.js.versioned.mustache
@@ -20,17 +20,17 @@ export default class FacebookAdsApi {
   accessToken: string;
   locale: string;
   static _defaultApi: FacebookAdsApi;
-  static get VERSION() {
+  static get VERSION(): string {
     return 'v{{api_version_num_only}}';
   }
-  static get SDK_VERSION() {
+  static get SDK_VERSION(): string {
     return '{{sdk_version}}';
   }
-  static get GRAPH() {
+  static get GRAPH(): string {
     return 'https://graph.facebook.com';
   }
 
-  static get GRAPH_VIDEO () {
+  static get GRAPH_VIDEO(): string {
     return 'https://graph-video.facebook.com';
   }
 
@@ -67,7 +67,7 @@ export default class FacebookAdsApi {
     this._defaultApi = api;
   }
 
-  static getDefaultApi() {
+  static getDefaultApi(): FacebookAdsApi {
     return this._defaultApi;
   }
 
@@ -149,7 +149,7 @@ export default class FacebookAdsApi {
       });
   }
 
-  static _encodeParams(params: Object) {
+  static _encodeParams(params: Object): string {
     return Object.keys(params)
       .map(key => {
         var param = params[key];

--- a/templates/nodejs/src/objects/ad-video.js
+++ b/templates/nodejs/src/objects/ad-video.js
@@ -52,7 +52,7 @@ export default class AdVideo extends AbstractCrudObject {
     batch: FacebookAdsBatchApi,
     failureHandler: Function,
     successHandler: Function,
-  ) {
+  ): any {
     let response = null;
     var spec = this.slideshow_spec;
     if (spec) {

--- a/templates/nodejs/src/utils.js
+++ b/templates/nodejs/src/utils.js
@@ -12,7 +12,7 @@ export default class Utils {
     return str.replace(/^\/|\/$/g, '');
   }
 
-  static removePreceedingSlash(str: string) {
+  static removePreceedingSlash(str: string): string {
     return str.length && str[0] === '/' ? str.slice(1) : str;
   }
 }

--- a/templates/nodejs/src/video-uploader.js
+++ b/templates/nodejs/src/video-uploader.js
@@ -61,7 +61,7 @@ class VideoUploadSession {
   _video: AdVideo;
   _waitForEncoding: boolean;
 
-  constructor(video: AdVideo, waitForEncoding: boolean = false) {
+  constructor(video: AdVideo, waitForEncoding: boolean = false): void {
     this._video = video;
     this._api = video.getApi();
 
@@ -162,7 +162,7 @@ class VideoUploadSession {
 class VideoUploadRequestManager {
   _api: FacebookAdsApi;
 
-  constructor(api: FacebookAdsApi) {
+  constructor(api: FacebookAdsApi): void {
     this._api = api;
   }
 
@@ -240,7 +240,7 @@ class VideoUploadTransferRequestManager extends VideoUploadRequestManager {
       });
       // Send the request
       try {
-        const response = await request.send([context.accountId, 'advideos']);
+        response = await request.send([context.accountId, 'advideos']);
         start_offset = parseInt(response['start_offset']);
         end_offset = parseInt(response['end_offset']);
       } catch (error) {
@@ -306,7 +306,7 @@ class VideoUploadRequestContext {
     return this._accountId;
   }
 
-  set accountId(accountId: string) {
+  set accountId(accountId: string): void {
     this._accountId = accountId;
   }
 
@@ -314,7 +314,7 @@ class VideoUploadRequestContext {
     return this._fileName;
   }
 
-  set fileName(fileName: string) {
+  set fileName(fileName: string): void {
     this._fileName = fileName;
   }
 
@@ -322,7 +322,7 @@ class VideoUploadRequestContext {
     return this._filePath;
   }
 
-  set filePath(filePath: string) {
+  set filePath(filePath: string): void {
     this._filePath = filePath;
   }
 
@@ -330,14 +330,14 @@ class VideoUploadRequestContext {
     return this._fileSize;
   }
 
-  set fileSize(fileSize: number) {
+  set fileSize(fileSize: number): void {
     this._fileSize = fileSize;
   }
   get name(): string {
     return this._name;
   }
 
-  set name(name: string) {
+  set name(name: string): void {
     this._name = name;
   }
 
@@ -345,7 +345,7 @@ class VideoUploadRequestContext {
     return this._sessionId;
   }
 
-  set sessionId(sessionId: string) {
+  set sessionId(sessionId: string): void {
     this._sessionId = sessionId;
   }
 
@@ -353,7 +353,7 @@ class VideoUploadRequestContext {
     return this._startOffset;
   }
 
-  set startOffset(startOffset: number) {
+  set startOffset(startOffset: number): void {
     this._startOffset = startOffset;
   }
 
@@ -361,7 +361,7 @@ class VideoUploadRequestContext {
     return this._endOffset;
   }
 
-  set endOffset(endOffset: number) {
+  set endOffset(endOffset: number): void {
     this._endOffset = endOffset;
   }
 
@@ -369,7 +369,7 @@ class VideoUploadRequestContext {
     return this._slideshowSpec;
   }
 
-  set slideshowSpec(slideshowSpec: SlideshowSpec) {
+  set slideshowSpec(slideshowSpec: SlideshowSpec): void {
     this._slideshowSpec = slideshowSpec;
   }
 
@@ -377,7 +377,7 @@ class VideoUploadRequestContext {
     return this._videoFileChunk;
   }
 
-  set videoFileChunk(videoFileChunk: string) {
+  set videoFileChunk(videoFileChunk: string): void {
     this._videoFileChunk = videoFileChunk;
   }
 }
@@ -455,7 +455,7 @@ class VideoEncodingStatusChecker {
     return;
   }
 
-  static getStatus(api: FacebookAdsApi, videoId: number) {
+  static getStatus(api: FacebookAdsApi, videoId: number): any {
     const result = api.call('GET', [videoId.toString()], {fields: 'status'});
     // $FlowFixMe
     return result['status'];


### PR DESCRIPTION
Summary:
1. `types_first` has been deprecated (https://flow.org/en/docs/config/options/). It produces an error `".flowconfig: Unsupported option specified! (types_first)"`. So, this diff removes it from `.flowconfig`

2. After removing it, there are a lot of flow errors, so, this diff fixes those flow errors.

Reviewed By: jingping2015

Differential Revision: D32056933

