### PR TITLE
Updated SavedAudience spec + new SavedAudienceSentence adobjects

### DIFF
--- a/api_specs/specs/SavedAudience.json
+++ b/api_specs/specs/SavedAudience.json
@@ -58,7 +58,7 @@
         },
         {
             "name": "sentence_lines",
-            "type": "list"
+            "type": "list<SavedAudienceSentence>"
         },
         {
             "name": "targeting",

--- a/api_specs/specs/SavedAudienceSentence.json
+++ b/api_specs/specs/SavedAudienceSentence.json
@@ -1,0 +1,13 @@
+{
+    "apis": [],
+    "fields": [
+        {
+            "name": "content",
+            "type": "string"
+        },
+        {
+            "name": "children",
+            "type": "list<string>"
+        }
+    ]
+}


### PR DESCRIPTION
## Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)

## Pull Request Details

Updated SavedAudience **sentence_lines** spec based on Graph Api Responses Observation ( no documentation available in Meta )

Documentation : https://developers.facebook.com/docs/marketing-api/reference/saved-audience

![Capture d’écran 2022-07-25 à 14 07 39](https://user-images.githubusercontent.com/15989780/180776770-7d07f430-7657-40b9-bb09-35d11c640e0a.png)

