### PR TITLE
Resolve more PHP 8.1 Deprecations

### DIFF
--- a/templates/php/src/FacebookAds/Cursor.php
+++ b/templates/php/src/FacebookAds/Cursor.php
@@ -29,7 +29,7 @@ use FacebookAds\Http\ResponseInterface;
 use FacebookAds\Http\Util;
 use FacebookAds\Object\AbstractObject;
 
-class Cursor implements \Iterator, \Countable, \arrayaccess {
+class Cursor implements \Iterator, \Countable, \ArrayAccess {
   /**
    * @var ResponseInterface
    */
@@ -419,7 +419,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
     return $this->indexRight;
   }
 
-  public function rewind() {
+  public function rewind() : void {
     $this->position = $this->indexLeft;
   }
 
@@ -435,19 +435,13 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
     $this->position = $position;
   }
 
-  /**
-   * @return AbstractObject|bool
-   */
-  public function current() {
+  public function current() : AbstractObject|bool {
     return isset($this->objects[$this->position])
       ? $this->objects[$this->position]
       : false;
   }
 
-  /**
-   * @return int
-   */
-  public function key() {
+  public function key() : ?int {
     return $this->position;
   }
 
@@ -468,7 +462,7 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
     }
   }
 
-  public function next() {
+  public function next() : void {
     if ($this->position == $this->getIndexRight()) {
       if ($this->getUseImplicitFetch()) {
         $this->fetchAfter();
@@ -485,17 +479,11 @@ class Cursor implements \Iterator, \Countable, \arrayaccess {
     }
   }
 
-  /**
-   * @return bool
-   */
-  public function valid() {
+  public function valid() : bool {
     return isset($this->objects[$this->position]);
   }
 
-  /**
-   * @return int
-   */
-  public function count() {
+  public function count() : int {
     return count($this->objects);
   }
 

--- a/templates/php/src/FacebookAds/Object/AbstractCrudObject.php.versioned.mustache
+++ b/templates/php/src/FacebookAds/Object/AbstractCrudObject.php.versioned.mustache
@@ -65,7 +65,7 @@ class AbstractCrudObject extends AbstractObject {
     // two integer connected by an underscore, like "123_456"
 
     $int_id = $id;
-    if (strpos($id, 'act_') === 0) {
+    if ($id !== null && strpos($id, 'act_') === 0) {
       $int_id = substr($id, 4);
     }
     $split_by_underscore = explode('_', (string) $id);


### PR DESCRIPTION
Related to https://github.com/facebook/facebook-business-sdk-codegen/pull/40

## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://developers.facebook.com/opensource/cla)

## Pull Request Details

Resolves php 8.1 deprecation from the closed PR above.

Further to this, commit https://github.com/facebook/facebook-business-sdk-codegen/commit/7a99f038b61f92938da9901db8eb2f232994ecc2 which was to supersede the PR does not implement return types for all of the cases that PR covered. This adds the remaining return types for functions implementing interfaces.