### PR TITLE
Updated ReachFrequencyPrediction spec + new nested ReachFrequencyPredictionPausePeriod adobjects

### DIFF
--- a/api_specs/specs/ReachFrequencyPrediction.json
+++ b/api_specs/specs/ReachFrequencyPrediction.json
@@ -270,7 +270,7 @@
         },
         {
             "name": "pause_periods",
-            "type": "list<Object>"
+            "type": "list<ReachFrequencyPredictionPausePeriod>"
         },
         {
             "name": "placement_breakdown",

--- a/api_specs/specs/ReachFrequencyPredictionPausePeriod.json
+++ b/api_specs/specs/ReachFrequencyPredictionPausePeriod.json
@@ -1,0 +1,21 @@
+{
+    "apis": [],
+    "fields": [
+        {
+            "name": "pauseStartDay",
+            "type": "int"
+        },
+        {
+            "name": "startTimeOffset",
+            "type": "int"
+        },
+        {
+            "name": "pauseEndDay",
+            "type": "int"
+        },
+        {
+            "name": "endTimeOffset",
+            "type": "int"
+        }
+    ]
+}


### PR DESCRIPTION
## Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Updated ReachFrequencyPrediction spec based on Graph Api Responses Observation ( no description available in Meta's documentation )

![Capture d’écran 2023-09-19 à 16 16 25](https://github.com/facebook/facebook-business-sdk-codegen/assets/15989780/6ea76ef7-bdbc-42c4-bb2c-5cdc7f18d0ae)