### PR TITLE
Updated AdVideo + new VideoStatus adobject

### DIFF
--- a/api_specs/specs/AdVideo.json
+++ b/api_specs/specs/AdVideo.json
@@ -661,7 +661,7 @@
         },
         {
             "name": "status",
-            "type": "Object"
+            "type": "VideoStatus"
         },
         {
             "name": "title",

--- a/api_specs/specs/VideoStatus.json
+++ b/api_specs/specs/VideoStatus.json
@@ -1,0 +1,29 @@
+{
+    "apis": [],
+    "fields": [
+        {
+            "name": "copyright_check_status",
+            "type": "Object"
+        },
+        {
+            "name": "processing_phase",
+            "type": "Object"
+        },
+        {
+            "name": "processing_progress",
+            "type": "unsigned int"
+        },
+        {
+            "name": "publishing_phase",
+            "type": "Object"
+        },
+        {
+            "name": "uploading_phase",
+            "type": "Object"
+        },
+        {
+            "name": "video_status",
+            "type": "string"
+        }
+    ]
+}


### PR DESCRIPTION
## Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Updated AdVideo `status` based on Documentation + API response observation 

Didn't know how to name additional types, so for the moment defined as `Object`

https://developers.facebook.com/docs/graph-api/reference/video/#fields

![Capture d’écran 2023-11-10 à 11 35 26](https://github.com/facebook/facebook-business-sdk-codegen/assets/15989780/70372187-45eb-449d-9e7b-ac8243d53fb2)

https://developers.facebook.com/docs/graph-api/reference/video-status/

![Capture d’écran 2023-11-10 à 11 32 53](https://github.com/facebook/facebook-business-sdk-codegen/assets/15989780/020915d2-3717-41ab-b57b-83290f3bc358)

Api response :

![Capture d’écran 2023-11-10 à 12 18 08](https://github.com/facebook/facebook-business-sdk-codegen/assets/15989780/5c4b9b40-354b-4b89-80f8-2b6cfe103141)
