### PR TITLE
Updated AdPromotedObject with whatsapp_phone_number

### DIFF
--- a/api_specs/specs/AdPromotedObject.json
+++ b/api_specs/specs/AdPromotedObject.json
@@ -92,6 +92,10 @@
         {
             "name": "retention_days",
             "type": "string"
+        },
+        {
+            "name": "whatsapp_phone_number",
+            "type": "string"
         }
     ]
 }


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Updated Adset `promoted_object` ( AdPromotedObject )  based on API response observation

Not present in the documentation : https://developers.facebook.com/docs/marketing-api/reference/ad-promoted-object/

First time seeing this field in my system : **2023-12-08**

![Capture d’écran 2023-12-08 à 13 19 16](https://github.com/facebook/facebook-business-sdk-codegen/assets/15989780/82d5d6b5-c8d0-47f3-883a-7b55843007e5)
