### PR TITLE
Updated Targeting with new age_range field & new TargetingAutomation AdObject

### DIFF
--- a/api_specs/specs/Targeting.json
+++ b/api_specs/specs/Targeting.json
@@ -14,6 +14,10 @@
             "type": "unsigned int"
         },
         {
+            "name": "age_range",
+            "type": "list<unsigned int>"
+        },
+        {
             "name": "alternate_auto_targeting_option",
             "type": "string"
         },
@@ -320,6 +324,10 @@
         {
             "name": "site_category",
             "type": "list<string>"
+        },
+        {
+            "name": "targeting_automation",
+            "type": "TargetingAutomation"
         },
         {
             "name": "targeting_optimization",

--- a/api_specs/specs/TargetingAutomation.json
+++ b/api_specs/specs/TargetingAutomation.json
@@ -1,0 +1,9 @@
+{
+    "apis": [],
+    "fields": [
+        {
+            "name": "advantage_audience",
+            "type": "unsigned int"
+        }
+    ]
+}


### PR DESCRIPTION
## Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Updated `Targeting` adobject based on API responses observation

Not documentation available for this adboject -> https://developers.facebook.com/docs/marketing-api/reference/saved-audience/

First time seeing this field in my system : 2024-02-07

![Capture d’écran 2024-02-07 à 12 11 01](https://github.com/facebook/facebook-business-sdk-codegen/assets/15989780/0b7bafb9-2b97-4fd1-9772-79a1a1ca89bd)

![Capture d’écran 2024-02-07 à 11 19 15](https://github.com/facebook/facebook-business-sdk-codegen/assets/15989780/92ef797e-0541-4f0e-b849-1348c44242c7)

![Capture d’écran 2024-02-07 à 12 00 39](https://github.com/facebook/facebook-business-sdk-codegen/assets/15989780/9425bad6-0d3e-4fb9-bd1a-add080c0eeb3)

