### PR TITLE
Fix issue with cursor params being reset before first successful api request in node sdk

### DIFF
--- a/templates/nodejs/src/cursor.js
+++ b/templates/nodejs/src/cursor.js
@@ -48,7 +48,7 @@ export default class Cursor extends Array<Object> {
     }
     this._api = sourceObject.getApi();
     this._targetClass = targetClass;
-    this.paging = {next: next};
+    this.paging = {next: next, params: params};
 
     this.clear = () => {
       this.length = 0;
@@ -84,7 +84,7 @@ export default class Cursor extends Array<Object> {
     this._loadPage = path => {
       const promise = new Promise((resolve, reject) => {
         this._api
-          .call('GET', path, params)
+          .call('GET', path, this.paging.params)
           .then((response: Object) => {
             const objects = this._buildObjectsFromResponse(response);
             this.set(objects);
@@ -95,9 +95,7 @@ export default class Cursor extends Array<Object> {
           })
           .catch(reject);
       });
-      if (params) {
-        params = undefined;
-      }
+
       return promise;
     };
 


### PR DESCRIPTION
## Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

This is related to already closed PR https://github.com/facebook/facebook-nodejs-business-sdk/commit/6a59270f89dbafbf45318b5829ff19f01eaca7d8

The fix that was merged into facebook-nodejs-business-sdk was overwritten by facebook-business-sdk-codegen. This PR will resole this issue.

The code was reverted in this commit: https://github.com/facebook/facebook-nodejs-business-sdk/commit/3221b621833c5574a2aea74d4186e0f31c41839a#diff-d5549bbccc9dc8ab94023cc12179c232fcc5d8d2385ad696ad29effcca16bc53
