### PR TITLE
Updated AdRuleHistory : added rule_id field

### DIFF
--- a/api_specs/specs/AdRuleHistory.json
+++ b/api_specs/specs/AdRuleHistory.json
@@ -26,6 +26,10 @@
             "type": "list<AdRuleHistoryResult>"
         },
         {
+            "name": "rule_id",
+            "type": "string"
+        },
+        {
             "name": "schedule_spec",
             "type": "AdRuleScheduleSpec"
         },


### PR DESCRIPTION
## Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Added missing `rule_id` field based on graph explorer suggestion

![Capture d’écran 2024-06-20 à 15 04 38](https://github.com/facebook/facebook-business-sdk-codegen/assets/15989780/2118dbb0-8f06-47d5-afac-fdab894a1477)


