### PR TITLE
Updated FundingSourceDetailsCoupon : added coupon_id , original_amount, original_display_amount, type fields

### DIFF
--- a/api_specs/specs/FundingSourceDetailsCoupon.json
+++ b/api_specs/specs/FundingSourceDetailsCoupon.json
@@ -10,6 +10,10 @@
             "type": "list<int>"
         },
         {
+            "name": "coupon_id",
+            "type": "string"
+        },
+        {
             "name": "currency",
             "type": "string"
         },
@@ -20,6 +24,18 @@
         {
             "name": "expiration",
             "type": "datetime"
+        },
+        {
+            "name": "original_amount",
+            "type": "int"
+        },
+        {
+            "name": "original_display_amount",
+            "type": "string"
+        },
+        {
+            "name": "type",
+            "type": "int"
         }
     ]
 }


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Added `coupon_id` , `original_amount`, `original_display_amount` and `type` on `FundingSourceDetailsCoupon` AdObject.

First time seen these fields in api response : **2024-07-17**

Based on what i saw in the new response seems to match with the Documentation, never seen `type` in my system for the moment but I added to the AdObject because the documentation mention it.

https://developers.facebook.com/docs/marketing-api/reference/ad-account#fields

![Capture d’écran 2024-07-17 à 10 40 09](https://github.com/user-attachments/assets/6325542f-a49d-4de3-a74c-1f7ddbf86fe4)

![Capture d’écran 2024-07-17 à 10 58 06](https://github.com/user-attachments/assets/13281741-de6c-4923-9752-4e7d9d065858)
