### PR TITLE
Updated AdPromotedObject : added value_semantic_type

### DIFF
--- a/api_specs/specs/AdPromotedObject.json
+++ b/api_specs/specs/AdPromotedObject.json
@@ -98,6 +98,10 @@
             "type": "string"
         },
         {
+            "name": "value_semantic_type",
+            "type": "AdPromotedObject_value_semantic_type"
+        },
+        {
             "name": "whatsapp_phone_number",
             "type": "string"
         }

--- a/api_specs/specs/enum_types.json
+++ b/api_specs/specs/enum_types.json
@@ -916,6 +916,14 @@
         ]
     },
     {
+        "name": "AdPromotedObject_value_semantic_type",
+        "node": "AdPromotedObject",
+        "field_or_param": "value_semantic_type",
+        "values": [
+            "VALUE"
+        ]
+    },
+    {
         "name": "AdRecommendation_confidence",
         "node": "AdRecommendation",
         "field_or_param": "confidence",


### PR DESCRIPTION
## Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Added missing `value_semantic_type` field in `AdPromotedObject` AdObject based on current documentation & api observation

First time seeing this field in my system : 2024-09-19

Only saw  the value :`VALUE` for the enum. 

<img width="976" alt="Capture d’écran 2024-09-19 à 12 28 36" src="https://github.com/user-attachments/assets/e5719769-0ba5-4c36-839c-3658a625d9cd">

https://developers.facebook.com/docs/marketing-api/reference/ad-promoted-object/

<img width="803" alt="Capture d’écran 2024-09-19 à 12 37 15" src="https://github.com/user-attachments/assets/5e3c0122-14ba-463d-af02-d5d1177a6f1a">
