### PR TITLE
Updated AdAssetFeedSpec : new AdAssetCallAdsConfigurationFeedSpec field

### DIFF
--- a/api_specs/specs/AdAssetCallAdsConfigurationFeedSpec.json
+++ b/api_specs/specs/AdAssetCallAdsConfigurationFeedSpec.json
@@ -1,0 +1,9 @@
+{
+    "apis": [],
+    "fields": [
+        {
+            "name": "call_destination_type",
+            "type": "string"
+        }
+    ]
+}

--- a/api_specs/specs/AdAssetFeedSpec.json
+++ b/api_specs/specs/AdAssetFeedSpec.json
@@ -26,6 +26,10 @@
             "type": "list<AdAssetFeedSpecBody>"
         },
         {
+            "name": "call_ads_configuration",
+            "type": "AdAssetCallAdsConfigurationFeedSpec"
+        },
+        {
             "name": "call_to_action_types",
             "type": "list<AdAssetFeedSpec_call_to_action_types>"
         },


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Added missing `call_ads_configuration` field in AdAssetFeedSpec AdObject based on current documentation & api observation

First time seeing this field in my system : 2024-10-04

https://developers.facebook.com/docs/marketing-api/reference/ad-asset-feed-spec/

<img width="814" alt="Capture d’écran 2024-10-04 à 13 12 54" src="https://github.com/user-attachments/assets/4de683c4-4409-4598-a781-ee604e76ab7b">



<img width="915" alt="Capture d’écran 2024-10-04 à 12 57 14" src="https://github.com/user-attachments/assets/1f81d8e6-4c7e-4d73-9867-d993ff7d0d7a">
