### PR TITLE
Updated AdCreativeFeatureCustomizations : new image_crop_style field

### DIFF
--- a/api_specs/specs/AdCreativeFeatureCustomizations.json
+++ b/api_specs/specs/AdCreativeFeatureCustomizations.json
@@ -4,6 +4,10 @@
         {
             "name": "showcase_card_display",
             "type": "string"
+        },
+        {
+            "name": "image_crop_style",
+            "type": "string"
         }
     ]
 }


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Added missing `image_crop_style` field in AdCreativeFeatureCustomizations AdObject based on api observation.

First time seeing this field in my system : 2024-10-15

<img width="1087" alt="Capture d’écran 2024-10-15 à 12 02 11" src="https://github.com/user-attachments/assets/1f177868-761c-48dc-b8ae-7b7df9d3d139">

