### PR TITLE
Updated FundingSourceDetailsCoupon : new start_date field

### DIFF
--- a/api_specs/specs/FundingSourceDetailsCoupon.json
+++ b/api_specs/specs/FundingSourceDetailsCoupon.json
@@ -32,6 +32,10 @@
         {
             "name": "original_display_amount",
             "type": "string"
+        },
+        {
+            "name": "start_date",
+            "type": "datetime"
         }
     ]
 }


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Added missing `start_date` field in `FundingSourceDetailsCoupon` AdObject based on api observation.

First time seeing this field in my system : 2024-10-19

<img width="1007" alt="Capture d’écran 2024-10-19 à 19 12 47" src="https://github.com/user-attachments/assets/9de62160-88fc-4af8-9b42-a1f7f9f92e9a">


