### PR TITLE
Updated AdCreativeFeaturesSpec : new multi_photo_to_video field

### DIFF
--- a/api_specs/specs/AdCreativeFeaturesSpec.json
+++ b/api_specs/specs/AdCreativeFeaturesSpec.json
@@ -142,6 +142,10 @@
             "type": "AdCreativeFeatureDetails"
         },
         {
+            "name": "multi_photo_to_video",
+            "type": "AdCreativeFeatureDetails"
+        },
+        {
             "name": "pac_relaxation",
             "type": "AdCreativeFeatureDetails"
         },


### PR DESCRIPTION
## Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Added missing `multi_photo_to_video` field in `AdCreativeFeaturesSpec` AdObject based on documentation observation.

https://developers.facebook.com/docs/marketing-api/reference/ad-creative-features-spec

<img width="1031" alt="Capture d’écran 2024-11-04 à 12 26 33" src="https://github.com/user-attachments/assets/67505763-c6fa-4078-b164-572094d2299e">


