### PR TITLE
Updated AdCreativeFeatureCustomizations : new text_extraction fields

### DIFF
--- a/api_specs/specs/AdCreativeFeatureCustomizations.json
+++ b/api_specs/specs/AdCreativeFeatureCustomizations.json
@@ -8,6 +8,10 @@
         {
             "name": "showcase_card_display",
             "type": "string"
+        },
+        {
+            "name": "text_extraction",
+            "type": "Object"
         }
     ]
 }


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Added missing `text_extraction` field in `AdCreativeFeatureCustomizations` AdObject based on API observations.

Also, I think a new adobject like below will be required but i don't know the Meta naming convention so I typed the field as Object for now

```json
{
    "apis": [],
    "fields": [
        {
            "name": "enroll_status",
            "type": "string"
        }
    ]
}
```

First saw in my system the : 2025-01-10

<img width="892" alt="Capture d’écran 2025-01-10 à 14 24 20" src="https://github.com/user-attachments/assets/79b35516-3280-44c9-8d74-e1b7443e2177" />


