### PR TITLE
Updated AdCampaignIssuesInfo : new opes_mid field

### DIFF
--- a/api_specs/specs/AdCampaignIssuesInfo.json
+++ b/api_specs/specs/AdCampaignIssuesInfo.json
@@ -20,6 +20,10 @@
         {
             "name": "level",
             "type": "string"
+        },
+        {
+            "name": "opes_mid",
+            "type": "string"
         }
     ]
 }


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Added missing `opes_mid` field in `AdCampaignIssuesInfo` AdObject based on API observations.

Not present in : https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-issues-info/

First saw in my system the : **2025-03-04**

Graph : {CAMPAIGN_ID}?fields=issues_info

<img width="1515" alt="Capture d’écran 2025-03-04 à 10 35 10" src="https://github.com/user-attachments/assets/f74ec343-3a66-4b18-8aed-b614c620c5a5" />