### PR TITLE
Updated enum_types : Added missing value for Smart Promotion Type ( ASC+ campaigns) 

### DIFF
--- a/api_specs/specs/enum_types.json
+++ b/api_specs/specs/enum_types.json
@@ -3628,7 +3628,8 @@
         "field_or_param": "smart_promotion_type",
         "values": [
             "GUIDED_CREATION",
-            "SMART_APP_PROMOTION"
+            "SMART_APP_PROMOTION",
+            "AUTOMATED_SHOPPING_ADS"
         ]
     },
     {


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Added missing enum value for `smart_promotion_type`

**Documentation :**  https://developers.facebook.com/docs/marketing-api/advantage-shopping-campaigns

<img width="847" alt="Capture d’écran 2025-05-13 à 12 01 20" src="https://github.com/user-attachments/assets/61ba8160-cd17-4ccb-a646-4cc915236895" />

<img width="884" alt="Capture d’écran 2025-05-13 à 13 40 34" src="https://github.com/user-attachments/assets/dc105174-c21d-44bc-bcbb-2a68a83d78a4" />


