### PR TITLE
Updated TargetingAutomation : Added adobject spec for  targeting automation individual_setting

### DIFF
--- a/api_specs/specs/TargetingAutomation.json
+++ b/api_specs/specs/TargetingAutomation.json
@@ -7,7 +7,7 @@
         },
         {
             "name": "individual_setting",
-            "type": "Object"
+            "type": "TargetingAutomationIndividualSetting"
         },
         {
             "name": "shared_audiences",

--- a/api_specs/specs/TargetingAutomationIndividualSetting.json
+++ b/api_specs/specs/TargetingAutomationIndividualSetting.json
@@ -1,0 +1,17 @@
+{
+    "apis": [],
+    "fields": [
+        {
+            "name": "geo",
+            "type": "unsigned int"
+        },
+        {
+            "name": "age",
+            "type": "unsigned int"
+        },
+        {
+            "name": "gender",
+            "type": "unsigned int"
+        }
+    ]
+}


### PR DESCRIPTION
## Checklist

- [X] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Added missing spec value for `individual_setting` in `TargetingAutomation` object

Spec based on documentation + Api responses observations

https://developers.facebook.com/docs/marketing-api/audiences/reference/advanced-targeting/

<img width="821" alt="Capture d’écran 2025-05-23 à 11 16 07" src="https://github.com/user-attachments/assets/7d9c8af7-816f-4834-9bc7-366d775b5b60" />

<img width="929" alt="Capture d’écran 2025-05-23 à 11 03 01" src="https://github.com/user-attachments/assets/36baec42-8127-466c-8d8b-746fe13cbbfd" />



