### PR TITLE
Updated Targeting : Added missing threads_positions field

### DIFF
--- a/api_specs/specs/Targeting.json
+++ b/api_specs/specs/Targeting.json
@@ -338,6 +338,10 @@
             "type": "TargetingRelaxation"
         },
         {
+            "name": "threads_positions",
+            "type": "list<string>"
+        },
+        {
             "name": "user_adclusters",
             "type": "list<IDName>"
         },


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Added missing `threads_positions` field in `Targeting` AdObject based on API observations.

First saw in my system the : **2025-05-28**

Graph : {ADSET_ID}?fields=targeting

<img width="825" alt="Capture d’écran 2025-06-02 à 09 43 31" src="https://github.com/user-attachments/assets/5a454527-1dea-4b6c-b716-12787f1d8bb2" />
