### PR TITLE
Updated AdCampaignFrequencyControlSpecs : Added type field

### DIFF
--- a/api_specs/specs/AdCampaignFrequencyControlSpecs.json
+++ b/api_specs/specs/AdCampaignFrequencyControlSpecs.json
@@ -12,6 +12,10 @@
         {
             "name": "max_frequency",
             "type": "unsigned int"
+        },
+        {
+            "name": "type",
+            "type": "string"
         }
     ]
 }


### PR DESCRIPTION
## Checklist

- [x] I've read the [Contributing Guidelines](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I've completed the [Contributor License Agreement](https://code.facebook.com/cla)

## Pull Request Details

Added missing `type` field in AdCampaignFrequencyControlSpecs AdObject based on API observations.

First saw in my system the : 2025-08-05

Graph : {ADSET_ID}?fields=frequency_control_specs

<img width="852" height="394" alt="Capture d’écran 2025-08-05 à 10 03 32" src="https://github.com/user-attachments/assets/10d0e90f-b9bb-4204-a29c-b31c9ac01f8b" />

Missing in documentation the 2025-08-05 : https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-frequency-control-specs/

<img width="811" height="452" alt="Capture d’écran 2025-08-05 à 10 15 30" src="https://github.com/user-attachments/assets/9ef2454a-ac10-4d3d-9bc7-cd7cfcd2e7cf" />



